### PR TITLE
chore: Deflake visitorId e2e assertion

### DIFF
--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -1,6 +1,5 @@
-import { test, expect, Page, request, APIRequestContext, ElementHandle } from '@playwright/test'
+import { test, expect, Page, request, APIRequestContext, Locator } from '@playwright/test'
 import { areVisitorIdAndRequestIdValid, wait } from '../utils'
-import assert from 'node:assert'
 
 const INT_VERSION = process.env.worker_version || ''
 const WORKER_PATH = process.env.worker_path || 'fpjs-worker-default'
@@ -36,6 +35,31 @@ interface V4GetResult {
 
 type Result = GetResult | V4GetResult
 
+function hasStringProperty(value: unknown, key: string): boolean {
+  return typeof value === 'object' && value !== null && key in value && typeof Reflect.get(value, key) === 'string'
+}
+
+function isResult(value: unknown): value is Result {
+  return (
+    (hasStringProperty(value, 'event_id') && hasStringProperty(value, 'visitor_id')) ||
+    (hasStringProperty(value, 'requestId') && hasStringProperty(value, 'visitorId'))
+  )
+}
+
+function getResultIds(jsonContent: Result): { visitorId: string; requestId: string } {
+  if ('event_id' in jsonContent) {
+    return {
+      visitorId: jsonContent.visitor_id,
+      requestId: jsonContent.event_id,
+    }
+  }
+
+  return {
+    visitorId: jsonContent.visitorId,
+    requestId: jsonContent.requestId,
+  }
+}
+
 test.describe('visitorId', () => {
   async function waitUntilOnline(
     reqContext: APIRequestContext,
@@ -70,29 +94,34 @@ test.describe('visitorId', () => {
     return waitUntilOnline(reqContext, expectedVersion, newRetryCounter, maxRetries)
   }
 
-  async function testForElement(el: ElementHandle<SVGElement | HTMLElement>) {
-    const textContent = await el.textContent()
-    expect(textContent != null).toStrictEqual(true)
-    assert(typeof textContent === 'string')
+  async function testForElement(locator: Locator) {
+    await expect(locator).toBeVisible()
 
-    let jsonContent: Result | undefined
-    try {
-      jsonContent = JSON.parse(textContent)
-    } catch (e) {
-      // do nothing
-    }
-    assert(jsonContent)
+    await expect
+      .poll(
+        async () => {
+          const textContent = await locator.textContent()
+          if (typeof textContent !== 'string' || textContent.trim() === '') {
+            return false
+          }
 
-    let visitorId = ''
-    let requestId = ''
-    if ('event_id' in jsonContent) {
-      visitorId = jsonContent.visitor_id
-      requestId = jsonContent.event_id
-    } else if ('requestId' in jsonContent) {
-      visitorId = jsonContent.visitorId
-      requestId = jsonContent.requestId
-    }
-    expect(areVisitorIdAndRequestIdValid(visitorId, requestId)).toStrictEqual(true)
+          try {
+            const jsonContent = JSON.parse(textContent)
+            if (!isResult(jsonContent)) {
+              return false
+            }
+            const { visitorId, requestId } = getResultIds(jsonContent)
+            return areVisitorIdAndRequestIdValid(visitorId, requestId)
+          } catch {
+            return false
+          }
+        },
+        {
+          message: `Expected ${await locator.evaluate((el) => el.outerHTML)} to contain a valid visitor result`,
+          timeout: 30000,
+        }
+      )
+      .toBe(true)
   }
 
   async function runTest(page: Page, url: string) {
@@ -101,9 +130,8 @@ test.describe('visitorId', () => {
       waitUntil: 'networkidle',
     })
 
-    await wait(5000)
-    await page.waitForSelector('#result > code').then(testForElement)
-    await page.waitForSelector('#cdn-result > code').then(testForElement)
+    await testForElement(page.locator('#result > code'))
+    await testForElement(page.locator('#cdn-result > code'))
   }
 
   for (const [name, url] of testCases) {

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -25,42 +25,20 @@ const workerDomain = process.env.test_client_domain
 // How long to wait for the result element to render and populate with valid JSON.
 const RESULT_TIMEOUT_MS = 30000
 
-interface GetResult {
-  requestId: string
-  visitorId: string
-  visitorFound: boolean
-}
-
-interface V4GetResult {
-  event_id: string
-  visitor_id: string
-}
-
-type Result = GetResult | V4GetResult
-
-function hasStringProperty(value: unknown, key: string): boolean {
-  return typeof value === 'object' && value !== null && key in value && typeof Reflect.get(value, key) === 'string'
-}
-
-function isResult(value: unknown): value is Result {
-  return (
-    (hasStringProperty(value, 'event_id') && hasStringProperty(value, 'visitor_id')) ||
-    (hasStringProperty(value, 'requestId') && hasStringProperty(value, 'visitorId'))
-  )
-}
-
-function getResultIds(jsonContent: Result): { visitorId: string; requestId: string } {
-  if ('event_id' in jsonContent) {
-    return {
-      visitorId: jsonContent.visitor_id,
-      requestId: jsonContent.event_id,
-    }
+// The result block renders JSON as either v3 { visitorId, requestId } or
+// v4 { visitor_id, event_id }. We only need it to eventually expose a well-formed
+// id pair; areVisitorIdAndRequestIdValid rejects anything missing or malformed.
+function hasValidResult(text: string): boolean {
+  let json: Record<string, string>
+  try {
+    json = JSON.parse(text)
+  } catch {
+    return false
   }
-
-  return {
-    visitorId: jsonContent.visitorId,
-    requestId: jsonContent.requestId,
+  if (typeof json !== 'object' || json === null) {
+    return false
   }
+  return areVisitorIdAndRequestIdValid(json.visitorId ?? json.visitor_id, json.requestId ?? json.event_id)
 }
 
 test.describe('visitorId', () => {
@@ -98,37 +76,13 @@ test.describe('visitorId', () => {
   }
 
   async function testForElement(locator: Locator) {
-    // Fold the visibility check into the poll so the whole wait shares a single
-    // timeout budget instead of stacking a separate (short) visibility timeout
-    // in front of it.
+    // Poll until the element is visible and its JSON exposes a valid id pair, so
+    // rendering and content population share one timeout budget.
     await expect
-      .poll(
-        async () => {
-          if (!(await locator.isVisible())) {
-            return false
-          }
-
-          const textContent = await locator.textContent()
-          if (typeof textContent !== 'string' || textContent.trim() === '') {
-            return false
-          }
-
-          try {
-            const jsonContent = JSON.parse(textContent)
-            if (!isResult(jsonContent)) {
-              return false
-            }
-            const { visitorId, requestId } = getResultIds(jsonContent)
-            return areVisitorIdAndRequestIdValid(visitorId, requestId)
-          } catch {
-            return false
-          }
-        },
-        {
-          message: 'Expected the result element to contain a valid visitor result',
-          timeout: RESULT_TIMEOUT_MS,
-        }
-      )
+      .poll(async () => (await locator.isVisible()) && hasValidResult((await locator.textContent()) ?? ''), {
+        message: 'Expected the result element to contain a valid visitor result',
+        timeout: RESULT_TIMEOUT_MS,
+      })
       .toBe(true)
   }
 

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -22,6 +22,9 @@ const testCases: [string, URL][] = [
 
 const workerDomain = process.env.test_client_domain
 
+// How long to wait for the result element to render and populate with valid JSON.
+const RESULT_TIMEOUT_MS = 30000
+
 interface GetResult {
   requestId: string
   visitorId: string
@@ -95,11 +98,16 @@ test.describe('visitorId', () => {
   }
 
   async function testForElement(locator: Locator) {
-    await expect(locator).toBeVisible()
-
+    // Fold the visibility check into the poll so the whole wait shares a single
+    // timeout budget instead of stacking a separate (short) visibility timeout
+    // in front of it.
     await expect
       .poll(
         async () => {
+          if (!(await locator.isVisible())) {
+            return false
+          }
+
           const textContent = await locator.textContent()
           if (typeof textContent !== 'string' || textContent.trim() === '') {
             return false
@@ -117,8 +125,8 @@ test.describe('visitorId', () => {
           }
         },
         {
-          message: `Expected ${await locator.evaluate((el) => el.outerHTML)} to contain a valid visitor result`,
-          timeout: 30000,
+          message: 'Expected the result element to contain a valid visitor result',
+          timeout: RESULT_TIMEOUT_MS,
         }
       )
       .toBe(true)
@@ -130,8 +138,12 @@ test.describe('visitorId', () => {
       waitUntil: 'networkidle',
     })
 
-    await testForElement(page.locator('#result > code'))
-    await testForElement(page.locator('#cdn-result > code'))
+    // Wait for both result blocks concurrently so the total wait is capped at a
+    // single RESULT_TIMEOUT_MS budget rather than the sum of both.
+    await Promise.all([
+      testForElement(page.locator('#result > code')),
+      testForElement(page.locator('#cdn-result > code')),
+    ])
   }
 
   for (const [name, url] of testCases) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,9 @@ import { PlaywrightTestConfig } from '@playwright/test'
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e/tests',
+  // Allow room for waiting until the worker is online, navigation, and the
+  // result-polling budget without hitting Playwright's default 30s per-test timeout.
+  timeout: 60_000,
 }
 
 export default config


### PR DESCRIPTION
## Summary

Replace the fixed 5s sleep in the visitorId e2e test with a polling assertion that waits until each result block renders JSON with a valid `visitorId`/`requestId` pair. Both blocks are polled concurrently, and the per-test timeout is raised to fit the online check, navigation, and polling.

## Why

The test was flaky: it read and parsed the result element once after a fixed delay, so it failed whenever the element had rendered but not yet been populated with valid JSON.