### PR TITLE
INTER-2335: Upgrade cookie dependency to v2

### DIFF
--- a/.changeset/upgrade-cookie-v2.md
+++ b/.changeset/upgrade-cookie-v2.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/cloudflare-worker-proxy": patch
+---
+
+Upgrade `cookie` dependency from v1 to v2. ~22% smaller bundle size. No customer-facing changes.

--- a/__tests__/utils/env.test.ts
+++ b/__tests__/utils/env.test.ts
@@ -9,9 +9,8 @@ describe('getIngressBaseHost', () => {
   it('throws when no value is set and no default is available', async () => {
     vi.resetModules()
     vi.doMock('../../src/config', () => ({ config: { ingressApi: null } }))
-    const { getIngressBaseHost: getIngressBaseHostNoDefault, Defaults: DefaultsNoDefault } = await import(
-      '../../src/env'
-    )
+    const { getIngressBaseHost: getIngressBaseHostNoDefault, Defaults: DefaultsNoDefault } =
+      await import('../../src/env')
 
     expect(() => getIngressBaseHostNoDefault({ ...DefaultsNoDefault, FPJS_INGRESS_BASE_HOST: null })).toThrow(
       'FPJS_INGRESS_BASE_HOST is not set and no default is available'

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "wrangler": "^4.113.0"
   },
   "dependencies": {
-    "cookie": "1.1.1"
+    "cookie": "2.0.1"
   },
   "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       cookie:
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 2.0.1
+        version: 2.0.1
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
@@ -1175,6 +1175,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
 
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
@@ -3371,6 +3375,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  cookie@2.0.1: {}
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,8 +1,8 @@
-import { parse } from 'cookie'
+import { parseCookie } from 'cookie'
 
 export function filterCookies(headers: Headers, filterFunc: (key: string) => boolean): Headers {
   const newHeaders = new Headers(headers)
-  const cookie = parse(headers.get('cookie') || '', { decode: (str) => str })
+  const cookie = parseCookie(headers.get('cookie') || '', { decode: (str: string) => str })
   const filteredCookieList = []
   for (const cookieName in cookie) {
     if (filterFunc(cookieName)) {


### PR DESCRIPTION
## Summary
- Upgrade `cookie` from `1.1.1` to `2.0.1`.
- Use the new `parseCookie` function.

## Customer impact
None. Cookie parsing is used internally to filter the `_iidt` cookie from request headers before proxying to the Fingerprint API.

## Benefits
- ~22% smaller bundle size (25.41 kB -> 19.80 kB)
