### PR TITLE
INTER-2370: Deflake visitorId e2e

### DIFF
--- a/__tests__/utils/env.test.ts
+++ b/__tests__/utils/env.test.ts
@@ -9,9 +9,8 @@ describe('getIngressBaseHost', () => {
   it('throws when no value is set and no default is available', async () => {
     vi.resetModules()
     vi.doMock('../../src/config', () => ({ config: { ingressApi: null } }))
-    const { getIngressBaseHost: getIngressBaseHostNoDefault, Defaults: DefaultsNoDefault } = await import(
-      '../../src/env'
-    )
+    const { getIngressBaseHost: getIngressBaseHostNoDefault, Defaults: DefaultsNoDefault } =
+      await import('../../src/env')
 
     expect(() => getIngressBaseHostNoDefault({ ...DefaultsNoDefault, FPJS_INGRESS_BASE_HOST: null })).toThrow(
       'FPJS_INGRESS_BASE_HOST is not set and no default is available'

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -29,6 +29,9 @@ const RESULT_TIMEOUT_MS = 15000
 // How many times to reload the page before failing.
 const MAX_PAGE_ATTEMPTS = 3
 
+// How often to re-check the result blocks while waiting within a single page load.
+const RESULT_POLL_INTERVAL_MS = 500
+
 // The result block renders JSON as either v3 { visitorId, requestId } or
 // v4 { visitor_id, event_id }. We only need it to eventually expose a well-formed
 // id pair; areVisitorIdAndRequestIdValid rejects anything missing or malformed.
@@ -83,20 +86,19 @@ test.describe('visitorId', () => {
     return (await locator.isVisible()) && hasValidResult((await locator.textContent()) ?? '')
   }
 
+  // Poll both result blocks until they hold a valid id pair or the timeout elapses.
   async function waitForResults(page: Page, timeout: number): Promise<boolean> {
-    try {
-      await expect
-        .poll(
-          async () =>
-            (await elementHasValidResult(page.locator('#result > code'))) &&
-            (await elementHasValidResult(page.locator('#cdn-result > code'))),
-          { timeout }
-        )
-        .toBe(true)
-      return true
-    } catch {
-      return false
-    }
+    const deadline = Date.now() + timeout
+    do {
+      if (
+        (await elementHasValidResult(page.locator('#result > code'))) &&
+        (await elementHasValidResult(page.locator('#cdn-result > code')))
+      ) {
+        return true
+      }
+      await wait(RESULT_POLL_INTERVAL_MS)
+    } while (Date.now() < deadline)
+    return false
   }
 
   async function runTest(page: Page, url: string) {

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -106,11 +106,7 @@ test.describe('visitorId', () => {
       console.log(`Running goto url (attempt ${attempt}/${MAX_PAGE_ATTEMPTS}): ${url}...`)
       try {
         // Navigation can itself fail, so retry it too rather than aborting the loop on the first error.
-        if (attempt === 1) {
-          await page.goto(url, { waitUntil: 'domcontentloaded' })
-        } else {
-          await page.reload({ waitUntil: 'domcontentloaded' })
-        }
+        await page.goto(url, { waitUntil: 'domcontentloaded' })
       } catch (err) {
         console.log(`Navigation failed on attempt ${attempt}/${MAX_PAGE_ATTEMPTS}: ${String(err)}`)
         if (attempt === MAX_PAGE_ATTEMPTS) {

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -22,8 +22,12 @@ const testCases: [string, URL][] = [
 
 const workerDomain = process.env.test_client_domain
 
-// How long to wait for the result element to render and populate with valid JSON.
-const RESULT_TIMEOUT_MS = 30000
+// How long to wait, per page load, for both result blocks to render and populate
+// with valid JSON before giving up on that load and reloading.
+const RESULT_TIMEOUT_MS = 15000
+
+// How many times to reload the page before failing.
+const MAX_PAGE_ATTEMPTS = 3
 
 // The result block renders JSON as either v3 { visitorId, requestId } or
 // v4 { visitor_id, event_id }. We only need it to eventually expose a well-formed
@@ -75,29 +79,44 @@ test.describe('visitorId', () => {
     return waitUntilOnline(reqContext, expectedVersion, newRetryCounter, maxRetries)
   }
 
-  async function testForElement(locator: Locator) {
-    // Poll until the element is visible and its JSON exposes a valid id pair, so
-    // rendering and content population share one timeout budget.
-    await expect
-      .poll(async () => (await locator.isVisible()) && hasValidResult((await locator.textContent()) ?? ''), {
-        message: 'Expected the result element to contain a valid visitor result',
-        timeout: RESULT_TIMEOUT_MS,
-      })
-      .toBe(true)
+  async function elementHasValidResult(locator: Locator): Promise<boolean> {
+    return (await locator.isVisible()) && hasValidResult((await locator.textContent()) ?? '')
+  }
+
+  async function waitForResults(page: Page, timeout: number): Promise<boolean> {
+    try {
+      await expect
+        .poll(
+          async () =>
+            (await elementHasValidResult(page.locator('#result > code'))) &&
+            (await elementHasValidResult(page.locator('#cdn-result > code'))),
+          { timeout }
+        )
+        .toBe(true)
+      return true
+    } catch {
+      return false
+    }
   }
 
   async function runTest(page: Page, url: string) {
-    console.log(`Running goto url: ${url}...`)
-    await page.goto(url, {
-      waitUntil: 'networkidle',
-    })
+    for (let attempt = 1; attempt <= MAX_PAGE_ATTEMPTS; attempt++) {
+      console.log(`Running goto url (attempt ${attempt}/${MAX_PAGE_ATTEMPTS}): ${url}...`)
+      if (attempt === 1) {
+        await page.goto(url, { waitUntil: 'domcontentloaded' })
+      } else {
+        await page.reload({ waitUntil: 'domcontentloaded' })
+      }
 
-    // Wait for both result blocks concurrently so the total wait is capped at a
-    // single RESULT_TIMEOUT_MS budget rather than the sum of both.
-    await Promise.all([
-      testForElement(page.locator('#result > code')),
-      testForElement(page.locator('#cdn-result > code')),
-    ])
+      if (await waitForResults(page, RESULT_TIMEOUT_MS)) {
+        return
+      }
+      console.log(`Attempt ${attempt} did not yield a valid result within ${RESULT_TIMEOUT_MS}ms`)
+    }
+
+    throw new Error(
+      `Expected both result elements to contain a valid visitor result within ${MAX_PAGE_ATTEMPTS} page loads`
+    )
   }
 
   for (const [name, url] of testCases) {

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -102,10 +102,19 @@ test.describe('visitorId', () => {
   async function runTest(page: Page, url: string) {
     for (let attempt = 1; attempt <= MAX_PAGE_ATTEMPTS; attempt++) {
       console.log(`Running goto url (attempt ${attempt}/${MAX_PAGE_ATTEMPTS}): ${url}...`)
-      if (attempt === 1) {
-        await page.goto(url, { waitUntil: 'domcontentloaded' })
-      } else {
-        await page.reload({ waitUntil: 'domcontentloaded' })
+      try {
+        // Navigation can itself fail, so retry it too rather than aborting the loop on the first error.
+        if (attempt === 1) {
+          await page.goto(url, { waitUntil: 'domcontentloaded' })
+        } else {
+          await page.reload({ waitUntil: 'domcontentloaded' })
+        }
+      } catch (err) {
+        console.log(`Navigation failed on attempt ${attempt}/${MAX_PAGE_ATTEMPTS}: ${String(err)}`)
+        if (attempt === MAX_PAGE_ATTEMPTS) {
+          throw err
+        }
+        continue
       }
 
       if (await waitForResults(page, RESULT_TIMEOUT_MS)) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,9 +2,13 @@ import { PlaywrightTestConfig } from '@playwright/test'
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e/tests',
-  // Allow room for waiting until the worker is online, navigation, and the
-  // result-polling budget without hitting Playwright's default 30s per-test timeout.
-  timeout: 60_000,
+  // Allow room for waiting until the worker is online, plus several navigation +
+  // result-polling attempts (MAX_PAGE_ATTEMPTS * RESULT_TIMEOUT_MS), without hitting
+  // Playwright's default 30s per-test timeout.
+  timeout: 90_000,
+  // Retry the whole test in CI so a transient cold-worker failure re-navigates with
+  // a fresh browser context instead of failing the job.
+  retries: process.env.CI ? 2 : 0,
 }
 
 export default config


### PR DESCRIPTION
## What

Rework the visitorId e2e test flow:

- `runTest` now reloads and retries the page up to `MAX_PAGE_ATTEMPTS` (`3`), polling both result blocks for `RESULT_TIMEOUT_MS` each load. It throws a clear error only after **all attempts** fail.
- The result poll now returns a boolean instead of throwing, so the loop decides when to reload.
- `goto`/`reload` use `waitUntil: 'domcontentloaded'` instead of `'networkidle'`.

## Why

The test was flaky and usually needed 4-5 reruns to pass.

Root cause: the test client page fetches the fingerprint result **once per page load**. When that single request hits a just-deployed Cloudflare worker route, the result element never populates, and the existing 30s poll can't recover it, since nothing on the page retries.

Reloading re-runs the agent, giving the warming worker another chance. `networkidle` is also ⚠️ ⚠️  [discouraged by Playwright](https://playwright.dev/docs/api/class-page#page-goto) and unreliable here because the FPJS agent keeps the network busy; the poll already handles content readiness.