### PR TITLE
Add playwright trace upload to e2etest CI workflow

### DIFF
--- a/.github/workflows/teste2e.yml
+++ b/.github/workflows/teste2e.yml
@@ -72,7 +72,7 @@ jobs:
             --arg agent_download_path "${{ steps.random-path-generator.outputs.AGENT_DOWNLOAD_PATH }}" \
             --arg proxy_secret "secret" \
             --arg fpjs_ingress_base_host "${{secrets.MOCK_INGRESS_API}}" \
-            '.name = $name | .route = $route | .vars.GET_RESULT_PATH = $get_result_path | .vars.AGENT_SCRIPT_DOWNLOAD_PATH = $agent_download_path | .vars.PROXY_SECRET = $proxy_secret | .vars.FPJS_INGRESS_BASE_HOST = $fpjs_ingress_base_host' \
+            '.name = $name | .route = $route | .vars.GET_RESULT_PATH = $get_result_path | .vars.AGENT_SCRIPT_DOWNLOAD_PATH = $agent_download_path | .vars.PROXY_SECRET = $proxy_secret | .vars.FPJS_INGRESS_BASE_HOST = $fpjs_ingress_base_host | .observability = {enabled: true, logs: {enabled: true}, traces: {enabled: true}}' \
             e2e-deploy/wrangler.json > e2e-deploy/wrangler.json.tmp && mv e2e-deploy/wrangler.json.tmp e2e-deploy/wrangler.json
 
       - name: Set compatibility date
@@ -177,7 +177,7 @@ jobs:
             --arg get_result_path "${{ steps.random-path-generator.outputs.GET_RESULT_PATH }}" \
             --arg agent_download_path "${{ steps.random-path-generator.outputs.AGENT_DOWNLOAD_PATH }}" \
             --arg proxy_secret "${{ secrets.PROXY_SECRET }}" \
-            '.name = $name | .route = $route | .vars.GET_RESULT_PATH = $get_result_path | .vars.AGENT_SCRIPT_DOWNLOAD_PATH = $agent_download_path | .vars.PROXY_SECRET = $proxy_secret' \
+            '.name = $name | .route = $route | .vars.GET_RESULT_PATH = $get_result_path | .vars.AGENT_SCRIPT_DOWNLOAD_PATH = $agent_download_path | .vars.PROXY_SECRET = $proxy_secret | .observability = {enabled: true, logs: {enabled: true}, traces: {enabled: true}}' \
             e2e-deploy/wrangler.json > e2e-deploy/wrangler.json.tmp && mv e2e-deploy/wrangler.json.tmp e2e-deploy/wrangler.json
 
       - name: Set compatibility date
@@ -207,7 +207,11 @@ jobs:
       
       - name: Install playwright dependencies
         run: pnpm exec playwright install
-      
+
+      - name: Wait for some time for the worker to come online
+        run: sleep 180
+        shell: bash
+
       - name: Run test
         run: pnpm test:e2e
         env:
@@ -216,7 +220,50 @@ jobs:
           worker_path: ${{steps.random-path-generator.outputs.WORKER_PATH}}
           get_result_path: ${{ steps.random-path-generator.outputs.GET_RESULT_PATH }}
           agent_download_path: ${{ steps.random-path-generator.outputs.AGENT_DOWNLOAD_PATH }}
-      
+
+      - name: Mask secret domain in Playwright traces
+        if: failure() || runner.debug == '1'
+        env:
+          TEST_CLIENT_DOMAIN: ${{ secrets.TEST_CLIENT_DOMAIN }}
+          PLACEHOLDER: "TEST_CLIENT_DOMAIN"
+        run: |
+          set -euo pipefail
+          if [ -z "${TEST_CLIENT_DOMAIN:-}" ]; then
+            echo "TEST_CLIENT_DOMAIN is not set; nothing to mask."
+            exit 0
+          fi
+          [ -d test-results ] || { echo "No test-results directory"; exit 0; }
+
+          mask() {
+            find "$1" -type f -exec perl -pi -e \
+              'BEGIN { $d = $ENV{TEST_CLIENT_DOMAIN}; $p = $ENV{PLACEHOLDER} } s/\Q$d\E/$p/g' {} +
+          }
+
+          root="$(pwd)"
+          find test-results -type f -name '*.zip' -print | while IFS= read -r zip; do
+            tmp="$(mktemp -d)"
+            if unzip -q -o "$zip" -d "$tmp"; then
+              mask "$tmp"
+              (cd "$tmp" && zip -q -r -X "$root/$zip.masked" .)
+              mv "$root/$zip.masked" "$root/$zip"
+            fi
+            rm -rf "$tmp"
+          done
+
+          find test-results -type f ! -name '*.zip' -exec perl -pi -e \
+            'BEGIN { $d = $ENV{TEST_CLIENT_DOMAIN}; $p = $ENV{PLACEHOLDER} } s/\Q$d\E/$p/g' {} +
+
+          echo "Masked TEST_CLIENT_DOMAIN in Playwright reports."
+
+      - name: Upload Playwright traces
+        if: failure() || runner.debug == '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ matrix.default_compatibility_date }}
+          path: test-results/
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Clean up worker
         run: |
           curl -i -X DELETE "https://api.cloudflare.com/client/v4/accounts/${{secrets.CF_ACCOUNT_ID}}/workers/scripts/${{steps.random-path-generator.outputs.WORKER_NAME}}" -H"Authorization: bearer ${{secrets.CF_API_TOKEN}}"

--- a/e2e/tests/visitorId.spec.ts
+++ b/e2e/tests/visitorId.spec.ts
@@ -42,7 +42,7 @@ function hasValidResult(text: string): boolean {
 }
 
 test.describe('visitorId', () => {
-  async function waitUntilOnline(
+  async function waitUntilStatusOnline(
     reqContext: APIRequestContext,
     expectedVersion: string,
     retryCounter = 0,
@@ -72,7 +72,7 @@ test.describe('visitorId', () => {
     }
 
     await wait(1000)
-    return waitUntilOnline(reqContext, expectedVersion, newRetryCounter, maxRetries)
+    return waitUntilStatusOnline(reqContext, expectedVersion, newRetryCounter, maxRetries)
   }
 
   async function testForElement(locator: Locator) {
@@ -86,25 +86,63 @@ test.describe('visitorId', () => {
       .toBe(true)
   }
 
+  function attachDiagnostics(page: Page) {
+    page.on('console', (msg) => console.log(`[browser console:${msg.type()}] ${msg.text()}`))
+    page.on('pageerror', (err) => console.log(`[browser pageerror] ${String(err)}`))
+    page.on('requestfailed', (req) =>
+      console.log(`[requestfailed] ${req.method()} ${req.url()} -> ${req.failure()?.errorText ?? 'unknown'}`)
+    )
+    page.on('response', (res) => {
+      if (res.status() >= 400) {
+        console.log(`[response ${res.status()}] ${res.request().method()} ${res.url()}`)
+      }
+    })
+  }
+
+  async function dumpPageState(page: Page) {
+    if (page.isClosed()) {
+      console.log('[debug] page/context already closed; see the uploaded trace')
+      return
+    }
+
+    const readText = (selector: string) =>
+      page
+        .locator(selector)
+        .textContent({ timeout: 1000 })
+        .catch((err) => `<unavailable: ${String(err)}>`)
+
+    console.log(`[debug] page.url()=${page.url()}`)
+    console.log(`[debug] #result > code = ${await readText('#result > code')}`)
+    console.log(`[debug] #cdn-result > code = ${await readText('#cdn-result > code')}`)
+    const content = await page.content().catch((err) => `<unavailable: ${String(err)}>`)
+    console.log(`[debug] page content:\n${content}`)
+  }
+
   async function runTest(page: Page, url: string) {
+    attachDiagnostics(page)
     console.log(`Running goto url: ${url}...`)
     await page.goto(url, {
       waitUntil: 'networkidle',
     })
 
-    // Wait for both result blocks concurrently so the total wait is capped at a
-    // single RESULT_TIMEOUT_MS budget rather than the sum of both.
-    await Promise.all([
-      testForElement(page.locator('#result > code')),
-      testForElement(page.locator('#cdn-result > code')),
-    ])
+    try {
+      // Wait for both result blocks concurrently so the total wait is capped at a
+      // single RESULT_TIMEOUT_MS budget rather than the sum of both.
+      await Promise.all([
+        testForElement(page.locator('#result > code')),
+        testForElement(page.locator('#cdn-result > code')),
+      ])
+    } catch (err) {
+      await dumpPageState(page)
+      throw err
+    }
   }
 
   for (const [name, url] of testCases) {
     test(`should show visitorId in the HTML (NPM & CDN) - ${name}`, async ({ page }) => {
       const reqContext = await request.newContext()
-      const isOnline = await waitUntilOnline(reqContext, INT_VERSION)
-      expect(isOnline).toBeTruthy()
+      const isStatusOnline = await waitUntilStatusOnline(reqContext, INT_VERSION)
+      expect(isStatusOnline).toBeTruthy()
 
       await runTest(page, url.href)
     })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,11 @@ const config: PlaywrightTestConfig = {
   // Allow room for waiting until the worker is online, navigation, and the
   // result-polling budget without hitting Playwright's default 30s per-test timeout.
   timeout: 60_000,
+  use: {
+    trace: { mode: 'on', screenshots: false },
+    screenshot: 'off',
+    video: 'off',
+  },
 }
 
 export default config


### PR DESCRIPTION
Adds a Playwright trace upload step to the e2e test CI workflow. It uploads the trace report when a test fails or when the run is in debug mode.

It also adds a `sleep` step to wait for workers to be updated.